### PR TITLE
Log python numbers instead of tensors for gradients

### DIFF
--- a/src/learners/actor_critic_learner.py
+++ b/src/learners/actor_critic_learner.py
@@ -93,7 +93,7 @@ class ActorCriticLearner:
 
             self.logger.log_stat("advantage_mean", (advantages * mask).sum().item() / mask.sum().item(), t_env)
             self.logger.log_stat("pg_loss", pg_loss.item(), t_env)
-            self.logger.log_stat("agent_grad_norm", grad_norm, t_env)
+            self.logger.log_stat("agent_grad_norm", grad_norm.item(), t_env)
             self.logger.log_stat("pi_max", (pi.max(dim=-1)[0] * mask).sum().item() / mask.sum().item(), t_env)
             self.log_stats_t = t_env
 
@@ -123,7 +123,7 @@ class ActorCriticLearner:
         self.critic_optimiser.step()
 
         running_log["critic_loss"].append(loss.item())
-        running_log["critic_grad_norm"].append(grad_norm)
+        running_log["critic_grad_norm"].append(grad_norm.item())
         mask_elems = mask.sum().item()
         running_log["td_error_abs"].append((masked_td_error.abs().sum().item() / mask_elems))
         running_log["q_taken_mean"].append((v * mask).sum().item() / mask_elems)

--- a/src/learners/coma_learner.py
+++ b/src/learners/coma_learner.py
@@ -96,7 +96,7 @@ class COMALearner:
 
             self.logger.log_stat("advantage_mean", (advantages * mask).sum().item() / mask.sum().item(), t_env)
             self.logger.log_stat("coma_loss", coma_loss.item(), t_env)
-            self.logger.log_stat("agent_grad_norm", grad_norm, t_env)
+            self.logger.log_stat("agent_grad_norm", grad_norm.item(), t_env)
             self.logger.log_stat("pi_max", (pi.max(dim=1)[0] * mask).sum().item() / mask.sum().item(), t_env)
             self.log_stats_t = t_env
 
@@ -130,7 +130,7 @@ class COMALearner:
         self.critic_optimiser.step()
 
         running_log["critic_loss"].append(loss.item())
-        running_log["critic_grad_norm"].append(grad_norm)
+        running_log["critic_grad_norm"].append(grad_norm.item())
         mask_elems = mask.sum().item()
         running_log["td_error_abs"].append((masked_td_error.abs().sum().item() / mask_elems))
         running_log["q_taken_mean"].append((q_taken * mask).sum().item() / mask_elems)

--- a/src/learners/maddpg_learner.py
+++ b/src/learners/maddpg_learner.py
@@ -117,8 +117,8 @@ class MADDPGLearner:
 
         if t_env - self.log_stats_t >= self.args.learner_log_interval:
             self.logger.log_stat("critic_loss", loss.item(), t_env)
-            self.logger.log_stat("critic_grad_norm", critic_grad_norm, t_env)
-            self.logger.log_stat("agent_grad_norm", agent_grad_norm, t_env)
+            self.logger.log_stat("critic_grad_norm", critic_grad_norm.item(), t_env)
+            self.logger.log_stat("agent_grad_norm", agent_grad_norm.item(), t_env)
             mask_elems = mask.sum().item()
             self.logger.log_stat("td_error_abs", masked_td_error.abs().sum().item() / mask_elems, t_env)
             self.logger.log_stat("q_taken_mean", (q_taken).sum().item() / mask_elems, t_env)

--- a/src/learners/ppo_learner.py
+++ b/src/learners/ppo_learner.py
@@ -113,7 +113,7 @@ class PPOLearner:
 
             self.logger.log_stat("advantage_mean", (advantages * mask).sum().item() / mask.sum().item(), t_env)
             self.logger.log_stat("pg_loss", pg_loss.item(), t_env)
-            self.logger.log_stat("agent_grad_norm", grad_norm, t_env)
+            self.logger.log_stat("agent_grad_norm", grad_norm.item(), t_env)
             self.logger.log_stat("pi_max", (pi.max(dim=-1)[0] * mask).sum().item() / mask.sum().item(), t_env)
             self.log_stats_t = t_env
 
@@ -143,7 +143,7 @@ class PPOLearner:
         self.critic_optimiser.step()
 
         running_log["critic_loss"].append(loss.item())
-        running_log["critic_grad_norm"].append(grad_norm)
+        running_log["critic_grad_norm"].append(grad_norm.item())
         mask_elems = mask.sum().item()
         running_log["td_error_abs"].append((masked_td_error.abs().sum().item() / mask_elems))
         running_log["q_taken_mean"].append((v * mask).sum().item() / mask_elems)

--- a/src/learners/q_learner.py
+++ b/src/learners/q_learner.py
@@ -113,7 +113,7 @@ class QLearner:
 
         if t_env - self.log_stats_t >= self.args.learner_log_interval:
             self.logger.log_stat("loss", loss.item(), t_env)
-            self.logger.log_stat("grad_norm", grad_norm, t_env)
+            self.logger.log_stat("grad_norm", grad_norm.item(), t_env)
             mask_elems = mask.sum().item()
             self.logger.log_stat("td_error_abs", (masked_td_error.abs().sum().item()/mask_elems), t_env)
             self.logger.log_stat("q_taken_mean", (chosen_action_qvals * mask).sum().item()/(mask_elems * self.args.n_agents), t_env)

--- a/src/learners/qtran_learner.py
+++ b/src/learners/qtran_learner.py
@@ -142,7 +142,7 @@ class QLearner:
             self.logger.log_stat("td_loss", td_loss.item(), t_env)
             self.logger.log_stat("opt_loss", opt_loss.item(), t_env)
             self.logger.log_stat("nopt_loss", nopt_loss.item(), t_env)
-            self.logger.log_stat("grad_norm", grad_norm, t_env)
+            self.logger.log_stat("grad_norm", grad_norm.item(), t_env)
             if self.args.mixer == "qtran_base":
                 mask_elems = mask.sum().item()
                 self.logger.log_stat("td_error_abs", (masked_td_error.abs().sum().item()/mask_elems), t_env)


### PR DESCRIPTION
This PR changes logging of gradients so that they are stored as plain python numbers instead of tensors.

This makes the log files such as `info.json` cleaner and also fixes `MongoObserver` from `sacred` dying when it was trying to log tensors.