### PR TITLE
Update dependencies in light of SMAC updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,8 @@ Pillow
 pluggy==0.7.1
 portpicker==1.2.0
 probscale
-protobuf==3.6.1
+protobuf
+importlib-metadata<5.0
 py==1.6.0
 pygame
 pyparsing==2.2.2


### PR DESCRIPTION
It seems like SMAC changed dependencies?

[This issue](https://github.com/uoe-agents/epymarl/issues/35) was happening for me and I fixed it with [this answer](https://github.com/uoe-agents/epymarl/issues/35#issuecomment-1295104539).

I could also update the README to add

> Running Python 3.7.13. Python 3.10 is not supported, since collections.Mapping is now deprecated.

I don't personally know how accurate that statement is, since I just used `v3.7.16` and it worked out for me.