### PR TITLE
Resolve the inconsistency between mpe MultiDiscrete and gym MultiDiscrete

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 absl-py
 attrs
 gym==0.21.0
+pyglet==1.5.0
 idna==2.7
 imageio
 lbforaging

--- a/src/envs/__init__.py
+++ b/src/envs/__init__.py
@@ -91,7 +91,7 @@ class _GymmaWrapper(MultiAgentEnv):
         self._obs = None
         self._info = None
 
-        self.longest_action_space = max(self._env.action_space, key=lambda x: x.n)
+        self.longest_action_space = max(self._env.action_space, key=lambda x: flatdim(x))
         self.longest_observation_space = max(
             self._env.observation_space, key=lambda x: x.shape
         )
@@ -150,7 +150,7 @@ class _GymmaWrapper(MultiAgentEnv):
     def get_avail_agent_actions(self, agent_id):
         """ Returns the available actions for agent_id """
         valid = flatdim(self._env.action_space[agent_id]) * [1]
-        invalid = [0] * (self.longest_action_space.n - len(valid))
+        invalid = [0] * (flatdim(self.longest_action_space) - len(valid))
         return valid + invalid
 
     def get_total_actions(self):

--- a/src/main.py
+++ b/src/main.py
@@ -93,7 +93,7 @@ if __name__ == '__main__':
         map_name = config_dict["env_args"]["map_name"]
     except:
         map_name = config_dict["env_args"]["key"]
-
+    map_name = "".join(x if (x.isalnum() or (x == "-")) else '_' for x in map_name)
 
     # now add all the config to sacred
     ex.add_config(config_dict)


### PR DESCRIPTION
- This bug causes training errors in **epymarl** when using the **simple_world_comm** environment.
- There is no `n` attribute in `MultiDiscrete`, which is the number of `Discrete` actions.
- Using `flatdim` in `gym.spaces` to get the number of `MultiDiscrete` actions . 

This pull request is associated with [Resolve the inconsistency between mpe MultiDiscrete and gym MultiDisc…](https://github.com/semitable/multiagent-particle-envs/commit/8345347414efa68c78647191e72d02f7bffd1d6d), in mpe. 
It has tested in _Python(3.9.16), OpenAI gym (0.21.0), numpy (1.23.5)_, with epymarl.

***
Commit [Convert a string to a valid file name under Windows(e.g. ':' in 'mpe:…](https://github.com/uoe-agents/epymarl/commit/daa30a7b1c909fae464e263d4665d4ceffd72c34) solve the bug epymarl creates **invalid folder names** in Windows. 

***
Commit [A high package version of pyglet can lead to unpredictable problems, …](https://github.com/uoe-agents/epymarl/commit/7be69b139730e3eef89ed24d184a0996571c94b7) solve the **pyglet version** bug.
