### PR TITLE
Updated readme to include installation instructions for MARBLER

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ python main.py --config=pac_ns --env-config=gymma with env_args.time_limit=1 env
 - [Table of Contents](#table-of-contents)
 - [Installation & Run instructions](#installation--run-instructions)
   - [Installing LBF, RWARE, and MPE](#installing-lbf-rware-and-mpe)
+  - [Installing MARBLER for Sim2Real Evaluation](#installing-marbler)
   - [Using A Custom Gym Environment](#using-a-custom-gym-environment)
 - [Run an experiment on a Gym environment](#run-an-experiment-on-a-gym-environment)
 - [Run a hyperparameter search](#run-a-hyperparameter-search)
@@ -89,6 +90,14 @@ and
 python3 src/main.py --config=qmix --env-config=gymma with env_args.time_limit=25 env_args.key="mpe:SimpleTag-v0" env_args.pretrained_wrapper="PretrainedTag"
 ```
 
+## Installing MARBLER
+
+[MARBLER](https://github.com/GT-STAR-Lab/MARBLER) is a gym built for [the Robotarium](https://www.robotarium.gatech.edu) to enable free and effortless Sim2Real evaluation of algorithms. Clone it and follow the instructions on its Github to install it.
+
+Example of using MARBLER:
+```sh
+python3 src/main.py --config=qmix --env-config=gymma with env_args.time_limit=10000 env_args.key="robotarium_gym:PredatorCapturePrey-v0"
+```
 
 ## Using A Custom Gym Environment
 


### PR DESCRIPTION
[MARBLER](https://github.com/GT-STAR-Lab/MARBLER) is a framework designed to make it easy to train MARL algorithms with the Robotarium's simulator and then deploy them on [the Robotarium](https://www.robotarium.gatech.edu) at Georgia Tech so you can easily run your algorithms on real robots for free. [The paper](https://arxiv.org/abs/2307.03891) was published at [IEEE MRS 2023](https://sites.bu.edu/mrs2023/program/awards/) where it won best paper. All of the evaluations were done using EPyMARL so its designed to be extremely easy to use with EPyMARL. I was hoping y'all could add a link to MARBLER in EPyMARL's readme with this commit? 