### PR TITLE
Implementing Individual Rewards and Recurrency in Critic Networks  

### DIFF
--- a/src/config/algs/ippo.yaml
+++ b/src/config/algs/ippo.yaml
@@ -26,6 +26,7 @@ entropy_coef: 0.01
 standardise_returns: False
 standardise_rewards: True
 use_rnn: True
+use_critic_rnn: True
 q_nstep: 5 # 1 corresponds to normal r + gammaV
 critic_type: "ac_critic"
 epochs: 4

--- a/src/config/algs/ippo_ns.yaml
+++ b/src/config/algs/ippo_ns.yaml
@@ -26,6 +26,7 @@ entropy_coef: 0.01
 standardise_returns: False
 standardise_rewards: True
 use_rnn: False
+use_critic_rnn: False
 epochs: 4
 eps_clip: 0.2
 q_nstep: 5 # 1 corresponds to normal r + gammaV

--- a/src/config/algs/mappo.yaml
+++ b/src/config/algs/mappo.yaml
@@ -21,7 +21,8 @@ obs_individual_obs: False
 agent_output_type: "pi_logits"
 learner: "ppo_learner"
 entropy_coef: 0.01
-use_rnn: False
+use_rnn: True
+use_critic_rnn: True
 standardise_returns: False
 standardise_rewards: False
 q_nstep: 5 # 1 corresponds to normal r + gammaV

--- a/src/config/algs/mappo_ns.yaml
+++ b/src/config/algs/mappo_ns.yaml
@@ -24,6 +24,7 @@ agent_output_type: "pi_logits"
 learner: "ppo_learner"
 entropy_coef: 0.01
 use_rnn: False
+use_critic_rnn: False
 standardise_returns: False
 standardise_rewards: True
 q_nstep: 5 # 1 corresponds to normal r + gammaV

--- a/src/config/envs/gymmai.yaml
+++ b/src/config/envs/gymmai.yaml
@@ -1,0 +1,14 @@
+env: "gymmai"
+
+env_args:
+  key: null
+  time_limit: 100
+  pretrained_wrapper: null
+
+test_greedy: True
+test_nepisode: 100
+test_interval: 50000
+log_interval: 50000
+runner_log_interval: 10000
+learner_log_interval: 10000
+t_max: 2050000

--- a/src/envs/__init__.py
+++ b/src/envs/__init__.py
@@ -191,29 +191,9 @@ class _GymmaWrapper(MultiAgentEnv):
 REGISTRY["gymma"] = partial(env_fn, env=_GymmaWrapper)
 
 
+# create gymma wrapper for individual rewards as a children class of _GymmaWrapper and override the step method to return rewards separately
 
-class _GymmaWrapperInd(MultiAgentEnv):
-    def __init__(self, key, time_limit, pretrained_wrapper, seed, **kwargs):
-        self.original_env = gym.make(f"{key}", **kwargs)
-        self.episode_limit = time_limit
-        self._env = TimeLimit(self.original_env, max_episode_steps=time_limit)
-        self._env = FlattenObservation(self._env)
-
-        if pretrained_wrapper:
-            self._env = getattr(pretrained, pretrained_wrapper)(self._env)
-
-        self.n_agents = self._env.n_agents
-        self._obs = None
-        self._info = None
-
-        self.longest_action_space = max(self._env.action_space, key=lambda x: x.n)
-        self.longest_observation_space = max(
-            self._env.observation_space, key=lambda x: x.shape
-        )
-
-        self._seed = seed
-        self._env.seed(self._seed)
-
+class _GymmaWrapperInd(_GymmaWrapper):
     def step(self, actions):
         """ Returns reward, terminated, info """
         actions = [int(a) for a in actions]
@@ -233,74 +213,5 @@ class _GymmaWrapperInd(MultiAgentEnv):
         if type(done) is list:
             done = all(done)
         return reward, done, {}
-
-    def get_obs(self):
-        """ Returns all agent observations in a list """
-        return self._obs
-
-    def get_obs_agent(self, agent_id):
-        """ Returns observation for agent_id """
-        raise self._obs[agent_id]
-
-    def get_obs_size(self):
-        """ Returns the shape of the observation """
-        return flatdim(self.longest_observation_space)
-
-    def get_state(self):
-        return np.concatenate(self._obs, axis=0).astype(np.float32)
-
-    def get_state_size(self):
-        """ Returns the shape of the state"""
-        if hasattr(self.original_env, 'state_size'):
-            return self.original_env.state_size
-        return self.n_agents * flatdim(self.longest_observation_space)
-
-    def get_avail_actions(self):
-        avail_actions = []
-        for agent_id in range(self.n_agents):
-            avail_agent = self.get_avail_agent_actions(agent_id)
-            avail_actions.append(avail_agent)
-        return avail_actions
-
-    def get_avail_agent_actions(self, agent_id):
-        """ Returns the available actions for agent_id """
-        valid = flatdim(self._env.action_space[agent_id]) * [1]
-        invalid = [0] * (self.longest_action_space.n - len(valid))
-        return valid + invalid
-
-    def get_total_actions(self):
-        """ Returns the total number of actions an agent could ever take """
-        # TODO: This is only suitable for a discrete 1 dimensional action space for each agent
-        return flatdim(self.longest_action_space)
-
-    def reset(self):
-        """ Returns initial observations and states"""
-        self._obs = self._env.reset()
-        self._obs = [
-            np.pad(
-                o,
-                (0, self.longest_observation_space.shape[0] - len(o)),
-                "constant",
-                constant_values=0,
-            )
-            for o in self._obs
-        ]
-        return self.get_obs(), self.get_state()
-
-    def render(self):
-        self._env.render()
-
-    def close(self):
-        self._env.close()
-
-    def seed(self):
-        return self._env.seed
-
-    def save_replay(self):
-        pass
-
-    def get_stats(self):
-        return {}
-
-
+    
 REGISTRY["gymmai"] = partial(env_fn, env=_GymmaWrapperInd)

--- a/src/envs/__init__.py
+++ b/src/envs/__init__.py
@@ -189,3 +189,118 @@ class _GymmaWrapper(MultiAgentEnv):
 
 
 REGISTRY["gymma"] = partial(env_fn, env=_GymmaWrapper)
+
+
+
+class _GymmaWrapperInd(MultiAgentEnv):
+    def __init__(self, key, time_limit, pretrained_wrapper, seed, **kwargs):
+        self.original_env = gym.make(f"{key}", **kwargs)
+        self.episode_limit = time_limit
+        self._env = TimeLimit(self.original_env, max_episode_steps=time_limit)
+        self._env = FlattenObservation(self._env)
+
+        if pretrained_wrapper:
+            self._env = getattr(pretrained, pretrained_wrapper)(self._env)
+
+        self.n_agents = self._env.n_agents
+        self._obs = None
+        self._info = None
+
+        self.longest_action_space = max(self._env.action_space, key=lambda x: x.n)
+        self.longest_observation_space = max(
+            self._env.observation_space, key=lambda x: x.shape
+        )
+
+        self._seed = seed
+        self._env.seed(self._seed)
+
+    def step(self, actions):
+        """ Returns reward, terminated, info """
+        actions = [int(a) for a in actions]
+        self._obs, reward, done, self._info = self._env.step(actions)
+        self._obs = [
+            np.pad(
+                o,
+                (0, self.longest_observation_space.shape[0] - len(o)),
+                "constant",
+                constant_values=0,
+            )
+            for o in self._obs
+        ]
+
+        # if type(reward) is list:
+        #     reward = sum(reward)
+        if type(done) is list:
+            done = all(done)
+        return reward, done, {}
+
+    def get_obs(self):
+        """ Returns all agent observations in a list """
+        return self._obs
+
+    def get_obs_agent(self, agent_id):
+        """ Returns observation for agent_id """
+        raise self._obs[agent_id]
+
+    def get_obs_size(self):
+        """ Returns the shape of the observation """
+        return flatdim(self.longest_observation_space)
+
+    def get_state(self):
+        return np.concatenate(self._obs, axis=0).astype(np.float32)
+
+    def get_state_size(self):
+        """ Returns the shape of the state"""
+        if hasattr(self.original_env, 'state_size'):
+            return self.original_env.state_size
+        return self.n_agents * flatdim(self.longest_observation_space)
+
+    def get_avail_actions(self):
+        avail_actions = []
+        for agent_id in range(self.n_agents):
+            avail_agent = self.get_avail_agent_actions(agent_id)
+            avail_actions.append(avail_agent)
+        return avail_actions
+
+    def get_avail_agent_actions(self, agent_id):
+        """ Returns the available actions for agent_id """
+        valid = flatdim(self._env.action_space[agent_id]) * [1]
+        invalid = [0] * (self.longest_action_space.n - len(valid))
+        return valid + invalid
+
+    def get_total_actions(self):
+        """ Returns the total number of actions an agent could ever take """
+        # TODO: This is only suitable for a discrete 1 dimensional action space for each agent
+        return flatdim(self.longest_action_space)
+
+    def reset(self):
+        """ Returns initial observations and states"""
+        self._obs = self._env.reset()
+        self._obs = [
+            np.pad(
+                o,
+                (0, self.longest_observation_space.shape[0] - len(o)),
+                "constant",
+                constant_values=0,
+            )
+            for o in self._obs
+        ]
+        return self.get_obs(), self.get_state()
+
+    def render(self):
+        self._env.render()
+
+    def close(self):
+        self._env.close()
+
+    def seed(self):
+        return self._env.seed
+
+    def save_replay(self):
+        pass
+
+    def get_stats(self):
+        return {}
+
+
+REGISTRY["gymmai"] = partial(env_fn, env=_GymmaWrapperInd)

--- a/src/envs/__init__.py
+++ b/src/envs/__init__.py
@@ -208,8 +208,6 @@ class _GymmaWrapperInd(_GymmaWrapper):
             for o in self._obs
         ]
 
-        # if type(reward) is list:
-        #     reward = sum(reward)
         if type(done) is list:
             done = all(done)
         return reward, done, {}

--- a/src/modules/critics/ac.py
+++ b/src/modules/critics/ac.py
@@ -16,14 +16,33 @@ class ACCritic(nn.Module):
 
         # Set up network layers
         self.fc1 = nn.Linear(input_shape, args.hidden_dim)
-        self.fc2 = nn.Linear(args.hidden_dim, args.hidden_dim)
+        if self.args.use_critic_rnn:
+            self.rnn = nn.GRUCell(args.hidden_dim, args.hidden_dim)
+        else:
+            self.rnn = nn.Linear(args.hidden_dim, args.hidden_dim)
         self.fc3 = nn.Linear(args.hidden_dim, 1)
+
+    def init_hidden(self):
+        # make hidden states on same device as model
+        return self.fc1.weight.new(1, self.args.hidden_dim).zero_()
 
     def forward(self, batch, t=None):
         inputs, bs, max_t = self._build_inputs(batch, t=t)
-        x = F.relu(self.fc1(inputs))
-        x = F.relu(self.fc2(x))
-        q = self.fc3(x)
+        # reshape inputs and initialize hidden states
+        inputs = inputs.view(max_t, bs*self.n_agents, -1)
+        if self.args.use_critic_rnn:
+            h = self.init_hidden().repeat(bs*self.n_agents, 1)
+        # rollout through max_t steps to get values
+        qs = []
+        for input in inputs:
+            x = F.relu(self.fc1(input))
+            if self.args.use_critic_rnn:
+                h = self.rnn(x, h)
+            else:
+                h = F.relu(self.rnn(x))
+            q = self.fc3(x)
+            qs.append(q)
+        q = th.stack(qs).view(bs, max_t, self.n_agents, 1)
         return q
 
     def _build_inputs(self, batch, t=None):

--- a/src/modules/critics/centralV_ns.py
+++ b/src/modules/critics/centralV_ns.py
@@ -4,6 +4,7 @@ import torch as th
 import torch.nn as nn
 import torch.nn.functional as F
 from modules.critics.mlp import MLP
+from modules.critics.rnn import RNN
 
 
 class CentralVCriticNS(nn.Module):
@@ -18,13 +19,19 @@ class CentralVCriticNS(nn.Module):
         self.output_type = "v"
 
         # Set up network layers
-        self.critics = [MLP(input_shape, args.hidden_dim, 1) for _ in range(self.n_agents)]
+        if self.args.use_critic_rnn:
+            self.critics = [RNN(input_shape, args.hidden_dim, 1) for _ in range(self.n_agents)]
+        else:
+            self.critics = [MLP(input_shape, args.hidden_dim, 1) for _ in range(self.n_agents)]
 
     def forward(self, batch, t=None):
         inputs, bs, max_t = self._build_inputs(batch, t=t)
         qs = []
         for i in range(self.n_agents):
-            q = self.critics[i](inputs)
+            if self.args.use_critic_rnn:
+                q = self.critics[i](inputs, max_t, bs)
+            else:
+                q = self.critics[i](inputs)
             qs.append(q.view(bs, max_t, 1, -1))
         q = th.cat(qs, dim=2)
         return q

--- a/src/modules/critics/rnn.py
+++ b/src/modules/critics/rnn.py
@@ -1,0 +1,32 @@
+# Description: RNN critic model.
+import torch as th
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+
+class RNN(nn.Module):
+    def __init__(self, input_shape, hidden_dim, output_dim):
+        super(RNN, self).__init__()
+        self.hidden_dim = hidden_dim
+        self.fc1 = nn.Linear(input_shape, hidden_dim)
+        self.rnn = nn.GRUCell(hidden_dim, hidden_dim)
+        self.fc3 = nn.Linear(hidden_dim, output_dim)
+
+    def init_hidden(self):
+        # make hidden states on same device as model
+        return self.fc1.weight.new(1, self.hidden_dim).zero_()
+
+    def forward(self, inputs, max_t, bs):
+        # make sure inputs are of the size (max_t, batch_size, input_shape)
+        inputs = inputs.view(max_t, bs, -1)
+        bs = inputs.size(1)
+        h = self.init_hidden().repeat(bs, 1)
+        qs = []
+        for input in inputs:
+            x = F.relu(self.fc1(input))
+            h = self.rnn(x, h)
+            q = self.fc3(h)
+            qs.append(q)
+        q = th.stack(qs).view(bs, max_t, 1)
+        return q

--- a/src/run.py
+++ b/src/run.py
@@ -105,6 +105,9 @@ def run_sequential(args, logger):
         "reward": {"vshape": (1,)},
         "terminated": {"vshape": (1,), "dtype": th.uint8},
     }
+    # For individual rewards in gymmai reward is of shape (1, n_agents)
+    if args.env=='gymmai':
+        scheme['reward'] = {'vshape': (args.n_agents,)}
     groups = {"agents": args.n_agents}
     preprocess = {"actions": ("actions_onehot", [OneHot(out_dim=args.n_actions)])}
 

--- a/src/runners/parallel_runner.py
+++ b/src/runners/parallel_runner.py
@@ -21,7 +21,6 @@ class ParallelRunner:
         env_args = [self.args.env_args.copy() for _ in range(self.batch_size)]
         for i in range(self.batch_size):
             env_args[i]["seed"] += i
-
         self.ps = [Process(target=env_worker, args=(worker_conn, CloudpickleWrapper(partial(env_fn, **env_arg))))
                             for env_arg, worker_conn in zip(env_args, self.worker_conns)]
 
@@ -145,7 +144,10 @@ class ParallelRunner:
                     # Remaining data for this current timestep
                     post_transition_data["reward"].append((data["reward"],))
 
-                    episode_returns[idx] += data["reward"]
+                    if self.args.env == "gymmai":
+                        episode_returns[idx] += sum(data["reward"])
+                    else:
+                        episode_returns[idx] += data["reward"]
                     episode_lengths[idx] += 1
                     if not test_mode:
                         self.env_steps_this_run += 1


### PR DESCRIPTION
Hi @LukasSchaefer ,

This pull request introduces two key enhancements:

1. Individual rewards for agents: Achieved by creating a `gymmai` subclass of the `gymma` wrapper. This feature has been successfully tested on IPPO and MAPPO algorithms across four environments (D-Goals, D-RWARE, D-LBF, Pressure Plate).

2. Recurrency in critic networks: Added to `ac` and `centralV` networks (and their not-shared counterparts) in the merged 'RNNCritic' branch, improving sequence processing over time.

Please review these changes and provide feedback.
