### PR TITLE
Create qtran.yaml

### DIFF
--- a/src/config/algs/qtran.yaml
+++ b/src/config/algs/qtran.yaml
@@ -1,0 +1,41 @@
+# --- QTRAN specific parameters ---
+
+# use epsilon greedy action selector
+action_selector: "epsilon_greedy"
+epsilon_start: 1.0
+epsilon_finish: 0.05
+epsilon_anneal_time: 50000
+evaluation_epsilon: 0.0
+
+runner: "episode"
+
+buffer_size: 5000
+
+# update the target network every {} episodes
+target_update_interval: 200
+
+
+obs_agent_id: True
+obs_last_action: False
+obs_individual_obs: False
+
+
+# use the Q_Learner to train
+standardise_returns: False
+standardise_rewards: True
+
+agent_output_type: "q"
+learner: "qtran_learner"
+double_q: True
+mixer: "qtran_base"
+use_rnn: False
+mixing_embed_dim: 64
+rnn_hidden_dim: 64
+
+name: "qtran"
+
+# QTRAN specific
+qtran_arch: "coma_critic"
+opt_loss: 1
+nopt_min_loss: 1
+network_size: "small"


### PR DESCRIPTION
Added qtran.yaml. The config file was previously missing from the config directory, which caused the QTRAN algorithm to be unusable.