### PR TITLE
Fix ParallelRunner training frequency and stale environment termination logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,16 @@ EPyMARL defines yaml configuration files for algorithms and environments under `
 
 Further environment configs (provided to the main script via `--env-config=...`) can be found in `src/config/envs`. Algorithm configs specifying algorithms and their hyperparameters (provided to the main script via `--config=...`) can be found in `src/config/algs`. To change hyperparameters or define a new algorithm, you can modify these yaml config files or create new ones.
 
+### `num_updates_per_rollout`
+
+The `num_updates_per_rollout` option (default: `1`) controls how many gradient updates are performed after each environment collection phase. For **off-policy, value-based algorithms** (e.g. QMIX, VDN, IQL) that use a large replay buffer, using parallel rollouts with batched updates can greatly improve training speed at the cost of some sample efficiency. 
+
+```sh
+python src/main.py --config=qmix --env-config=smaclite with env_args.time_limit=150 env_args.map_name="MMM" batch_size_run=30 num_updates_per_rollout=30 runner="parallel" 
+```
+
+**Do not use this with policy-gradient algorithms** (MAPPO, IPPO, IA2C, MAA2C, COMA, PAC). Their buffers hold exactly one rollout (`buffer_size == batch_size`), so repeated `sample()` calls return identical data. 
+
 # Run a hyperparameter search
 
 We include a script named `search.py` which reads a search configuration file (e.g. the included `search.config.example.yaml`) and runs a hyperparameter search in one or more tasks. The script can be run using

--- a/src/components/episode_buffer.py
+++ b/src/components/episode_buffer.py
@@ -86,6 +86,7 @@ class EpisodeBatch:
 
     def update(self, data, bs=slice(None), ts=slice(None), mark_filled=True):
         slices = self._parse_slices((bs, ts))
+        slices = tuple(slices)
         for k, v in data.items():
             if k in self.data.transition_data:
                 target = self.data.transition_data
@@ -147,6 +148,7 @@ class EpisodeBatch:
             return ret
         else:
             item = self._parse_slices(item)
+            item = tuple(item)
             new_data = self._new_data_sn()
             for k, v in self.data.transition_data.items():
                 new_data.transition_data[k] = v[item]

--- a/src/config/default.yaml
+++ b/src/config/default.yaml
@@ -8,6 +8,7 @@ common_reward: True  # Run experiment with common reward setup
 reward_scalarisation: "sum"  # How to aggregate rewards to single common reward (only used if common_reward is True)
 env_args: {} # Arguments for the environment
 batch_size_run: 1 # Number of environments to run in parallel
+num_updates_per_rollout: 1 # Gradient updates per environment rollout. >1 only useful for off-policy algorithms with large replay buffers.
 test_nepisode: 20 # Number of episodes to test for
 test_interval: 2000 # Test after {} timesteps have passed
 test_greedy: True # Use greedy evaluation (if False, will set epsilon floor to 0

--- a/src/controllers/basic_controller.py
+++ b/src/controllers/basic_controller.py
@@ -24,21 +24,16 @@ class BasicMAC:
         return chosen_actions
 
     def forward(self, ep_batch, t, bs=slice(None), test_mode=False):
-        # Slice the batch and hidden states to avoid running the RNNs on stale data from terminated envs
-        agent_inputs = self._build_inputs(ep_batch, t, bs=bs)
-        avail_actions = ep_batch["avail_actions"][bs, t]
+        # Slice batch and hidden states to only run on active (non-terminated) envs
+        ep_batch = ep_batch[bs]
+        agent_inputs = self._build_inputs(ep_batch, t)
+        avail_actions = ep_batch["avail_actions"][:, t]
 
-        is_subset = not isinstance(bs, slice)
-        hidden_in = self.hidden_states[bs] if is_subset else self.hidden_states
-        agent_outs, hidden_out = self.agent(agent_inputs, hidden_in)
-
-        if is_subset:
-            self.hidden_states[bs] = hidden_out.view_as(self.hidden_states[bs])
-        else:
-            self.hidden_states = hidden_out.view_as(self.hidden_states)
+        agent_outs, hidden_out = self.agent(agent_inputs, self.hidden_states[bs])
+        self.hidden_states[bs] = hidden_out.view_as(self.hidden_states[bs])
 
         # Softmax the agent outputs if they're policy logits
-        n_live = avail_actions.shape[0]
+        n_live = ep_batch.batch_size
         if self.agent_output_type == "pi_logits":
             if getattr(self.args, "mask_before_softmax", True):
                 # Make the logits for unavailable actions very negative to minimise their effect on the softmax
@@ -70,23 +65,21 @@ class BasicMAC:
     def _build_agents(self, input_shape):
         self.agent = agent_REGISTRY[self.args.agent](input_shape, self.args)
 
-    def _build_inputs(self, batch, t, bs=slice(None)):
+    def _build_inputs(self, batch, t):
         # Assumes homogenous agents with flat observations.
         # Other MACs might want to e.g. delegate building inputs to each agent
-        bs_data = batch[bs]
-        bs_size = bs_data.batch_size
-
+        bs = batch.batch_size
         inputs = []
-        inputs.append(bs_data["obs"][:, t])  # b1av
+        inputs.append(batch["obs"][:, t])  # b1av
         if self.args.obs_last_action:
             if t == 0:
-                inputs.append(th.zeros_like(bs_data["actions_onehot"][:, t]))
+                inputs.append(th.zeros_like(batch["actions_onehot"][:, t]))
             else:
-                inputs.append(bs_data["actions_onehot"][:, t-1])
+                inputs.append(batch["actions_onehot"][:, t-1])
         if self.args.obs_agent_id:
-            inputs.append(th.eye(self.n_agents, device=batch.device).unsqueeze(0).expand(bs_size, -1, -1))
+            inputs.append(th.eye(self.n_agents, device=batch.device).unsqueeze(0).expand(bs, -1, -1))
 
-        inputs = th.cat([x.reshape(bs_size * self.n_agents, -1) for x in inputs], dim=1)
+        inputs = th.cat([x.reshape(bs * self.n_agents, -1) for x in inputs], dim=1)
         return inputs
 
     def _get_input_shape(self, scheme):

--- a/src/controllers/basic_controller.py
+++ b/src/controllers/basic_controller.py
@@ -19,28 +19,38 @@ class BasicMAC:
     def select_actions(self, ep_batch, t_ep, t_env, bs=slice(None), test_mode=False):
         # Only select actions for the selected batch elements in bs
         avail_actions = ep_batch["avail_actions"][:, t_ep]
-        agent_outputs = self.forward(ep_batch, t_ep, test_mode=test_mode)
-        chosen_actions = self.action_selector.select_action(agent_outputs[bs], avail_actions[bs], t_env, test_mode=test_mode)
+        agent_outputs = self.forward(ep_batch, t_ep, bs=bs, test_mode=test_mode)
+        chosen_actions = self.action_selector.select_action(agent_outputs, avail_actions[bs], t_env, test_mode=test_mode)
         return chosen_actions
 
-    def forward(self, ep_batch, t, test_mode=False):
-        agent_inputs = self._build_inputs(ep_batch, t)
-        avail_actions = ep_batch["avail_actions"][:, t]
-        agent_outs, self.hidden_states = self.agent(agent_inputs, self.hidden_states)
+    def forward(self, ep_batch, t, bs=slice(None), test_mode=False):
+        # Slice the batch and hidden states to avoid running the RNNs on stale data from terminated envs
+        agent_inputs = self._build_inputs(ep_batch, t, bs=bs)
+        avail_actions = ep_batch["avail_actions"][bs, t]
+
+        is_subset = not isinstance(bs, slice)
+        hidden_in = self.hidden_states[bs] if is_subset else self.hidden_states
+        agent_outs, hidden_out = self.agent(agent_inputs, hidden_in)
+
+        if is_subset:
+            self.hidden_states[bs] = hidden_out.view_as(self.hidden_states[bs])
+        else:
+            self.hidden_states = hidden_out.view_as(self.hidden_states)
 
         # Softmax the agent outputs if they're policy logits
+        n_live = avail_actions.shape[0]
         if self.agent_output_type == "pi_logits":
-
             if getattr(self.args, "mask_before_softmax", True):
-                # Make the logits for unavailable actions very negative to minimise their affect on the softmax
-                reshaped_avail_actions = avail_actions.reshape(ep_batch.batch_size * self.n_agents, -1)
+                # Make the logits for unavailable actions very negative to minimise their effect on the softmax
+                reshaped_avail_actions = avail_actions.reshape(n_live * self.n_agents, -1)
                 agent_outs[reshaped_avail_actions == 0] = -1e10
             agent_outs = th.nn.functional.softmax(agent_outs, dim=-1)
 
-        return agent_outs.view(ep_batch.batch_size, self.n_agents, -1)
+        return agent_outs.view(n_live, self.n_agents, -1)
 
     def init_hidden(self, batch_size):
-        self.hidden_states = self.agent.init_hidden().unsqueeze(0).expand(batch_size, self.n_agents, -1)  # bav
+        self.hidden_states = self.agent.init_hidden().unsqueeze(0).expand(
+            batch_size, self.n_agents, -1).clone()  # bav
 
     def parameters(self):
         return self.agent.parameters()
@@ -60,21 +70,23 @@ class BasicMAC:
     def _build_agents(self, input_shape):
         self.agent = agent_REGISTRY[self.args.agent](input_shape, self.args)
 
-    def _build_inputs(self, batch, t):
+    def _build_inputs(self, batch, t, bs=slice(None)):
         # Assumes homogenous agents with flat observations.
         # Other MACs might want to e.g. delegate building inputs to each agent
-        bs = batch.batch_size
+        bs_data = batch[bs]
+        bs_size = bs_data.batch_size
+
         inputs = []
-        inputs.append(batch["obs"][:, t])  # b1av
+        inputs.append(bs_data["obs"][:, t])  # b1av
         if self.args.obs_last_action:
             if t == 0:
-                inputs.append(th.zeros_like(batch["actions_onehot"][:, t]))
+                inputs.append(th.zeros_like(bs_data["actions_onehot"][:, t]))
             else:
-                inputs.append(batch["actions_onehot"][:, t-1])
+                inputs.append(bs_data["actions_onehot"][:, t-1])
         if self.args.obs_agent_id:
-            inputs.append(th.eye(self.n_agents, device=batch.device).unsqueeze(0).expand(bs, -1, -1))
+            inputs.append(th.eye(self.n_agents, device=batch.device).unsqueeze(0).expand(bs_size, -1, -1))
 
-        inputs = th.cat([x.reshape(bs*self.n_agents, -1) for x in inputs], dim=1)
+        inputs = th.cat([x.reshape(bs_size * self.n_agents, -1) for x in inputs], dim=1)
         return inputs
 
     def _get_input_shape(self, scheme):

--- a/src/run.py
+++ b/src/run.py
@@ -201,16 +201,19 @@ def run_sequential(args, logger):
         buffer.insert_episode_batch(episode_batch)
 
         if buffer.can_sample(args.batch_size):
-            episode_sample = buffer.sample(args.batch_size)
+            n_updates = args.batch_size_run
 
-            # Truncate batch to only filled timesteps
-            max_ep_t = episode_sample.max_t_filled()
-            episode_sample = episode_sample[:, :max_ep_t]
+            for _ in range(n_updates):
+                episode_sample = buffer.sample(args.batch_size)
 
-            if episode_sample.device != args.device:
-                episode_sample.to(args.device)
+                # Truncate batch to only filled timesteps
+                max_ep_t = episode_sample.max_t_filled()
+                episode_sample = episode_sample[:, :max_ep_t]
 
-            learner.train(episode_sample, runner.t_env, episode)
+                if episode_sample.device != args.device:
+                    episode_sample.to(args.device)
+
+                learner.train(episode_sample, runner.t_env, episode)
 
         # Execute test runs once in a while
         n_test_runs = max(1, args.test_nepisode // runner.batch_size)

--- a/src/run.py
+++ b/src/run.py
@@ -201,7 +201,7 @@ def run_sequential(args, logger):
         buffer.insert_episode_batch(episode_batch)
 
         if buffer.can_sample(args.batch_size):
-            n_updates = args.batch_size_run
+            n_updates = args.num_updates_per_rollout
 
             for _ in range(n_updates):
                 episode_sample = buffer.sample(args.batch_size)
@@ -285,5 +285,18 @@ def args_sanity_check(config, _log):
         config["test_nepisode"] = (
             config["test_nepisode"] // config["batch_size_run"]
         ) * config["batch_size_run"]
+
+    is_pg_alg = config["buffer_size"] <= config["batch_size"]
+    is_parallel = config["runner"] == "parallel"
+    bs_run = config["batch_size_run"]
+    if is_pg_alg and config["num_updates_per_rollout"] > 1:
+        _log.warning("num_updates_per_rollout > 1 should not be used for on-policy algorithms.")
+
+    if (is_parallel and not is_pg_alg and config["num_updates_per_rollout"] < bs_run):
+        _log.warning(
+            f"num_updates_per_rollout ({config['num_updates_per_rollout']}) < batch_size_run ({bs_run}): "
+            f"This updates less frequently than episode_runner would. Set num_updates_per_rollout={bs_run} to match "
+            f"episode_runner update frequency, or use runner='episode' for better sample efficiency."
+        )
 
     return config

--- a/src/runners/parallel_runner.py
+++ b/src/runners/parallel_runner.py
@@ -154,23 +154,19 @@ class ParallelRunner:
                     if idx == 0 and test_mode and self.args.render:
                         parent_conn.send(("render", None))
 
-            # Update envs_not_terminated
-            envs_not_terminated = [
-                b_idx for b_idx, termed in enumerate(terminated) if not termed
-            ]
-            all_terminated = all(terminated)
-            if all_terminated:
-                break
-
             # Post step data we will insert for the current timestep
             post_transition_data = {"reward": [], "terminated": []}
             # Data for the next step we will insert in order to select an action
             pre_transition_data = {"state": [], "avail_actions": [], "obs": []}
 
+            # Track which envs contributed data this step (alive before receive)
+            envs_that_stepped = []
+
             # Receive data back for each unterminated env
             for idx, parent_conn in enumerate(self.parent_conns):
                 if not terminated[idx]:
                     data = parent_conn.recv()
+                    envs_that_stepped.append(idx)
                     # Remaining data for this current timestep
                     post_transition_data["reward"].append((data["reward"],))
 
@@ -194,10 +190,16 @@ class ParallelRunner:
                     pre_transition_data["avail_actions"].append(data["avail_actions"])
                     pre_transition_data["obs"].append(data["obs"])
 
-            # Add post_transiton data into the batch
+            # Recompute envs_not_terminated AFTER receiving new termination flags
+            envs_not_terminated = [
+                b_idx for b_idx, termed in enumerate(terminated) if not termed
+            ]
+            all_terminated = all(terminated)
+
+            # Post-transition data goes to ALL envs that stepped (includes just-terminated)
             self.batch.update(
                 post_transition_data,
-                bs=envs_not_terminated,
+                bs=envs_that_stepped,
                 ts=self.t,
                 mark_filled=False,
             )
@@ -205,10 +207,14 @@ class ParallelRunner:
             # Move onto the next timestep
             self.t += 1
 
-            # Add the pre-transition data
+            # Pre-transition data also goes to all envs that stepped, so their
+            # terminal observations are stored (needed by the learner for target Q)
             self.batch.update(
-                pre_transition_data, bs=envs_not_terminated, ts=self.t, mark_filled=True
+                pre_transition_data, bs=envs_that_stepped, ts=self.t, mark_filled=True
             )
+
+            if all_terminated:
+                break
 
         if not test_mode:
             self.t_env += self.env_steps_this_run


### PR DESCRIPTION
This PR addresses three issues in "run.py" and "parallel_runner.py" that caused significant performance degradation and potential logic errors when using parallel environments. 

### 1. Corrected training update ratio 
Previously in "run.py", the number of training updates = 1/B for each rollout phase, where B = args.batch_size_run. 
- Fixed by ensuring training frequency scales with number of episodes collected, matching behavior of standard `EpisodeRunner`. 

### 2. Stale termination mask 

In ParallelRunner, `envs_not_terminated` was computed BEFORE the env receive loop, making the select_actions() call potentially assigning values to agents incorrectly. 
- Fixed by moving mask computation after env receive. 

### 3. More efficient batches in BasicMAC 

To improve throughput, I also selected subsets of active envs for batches in `BasicMAC.forward()` (no need to update dead agents). 

**Related Issues:** 
- Possibly addresses #88 
- Fixes #79 

<img width="1552" height="388" alt="image" src="https://github.com/user-attachments/assets/eea479a8-534f-40d2-8fbb-e5b6b5baa64e" />

This shows that the (yellow) new parallel runs match performance of the (pink) sequential runs, 
greatly outperforming the previous (blue) parallel runs. It's faster too! 